### PR TITLE
Add member ordering to Gantt view

### DIFF
--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -161,6 +161,7 @@ export interface SavedViewState {
   rangeStart: string | null;
   rangeEnd: string | null;
   collapsedGroups: string[];
+  memberOrder?: string[];
 }
 
 export interface SavedViewItem {

--- a/renderer/src/components/GanttRow.tsx
+++ b/renderer/src/components/GanttRow.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
+import type {
+  CSSProperties,
+  DragEvent as ReactDragEvent,
+  MouseEvent as ReactMouseEvent
+} from 'react';
 import type { ListChildComponentProps } from 'react-window';
 import type { NormalizedTask, TaskUpdateInput } from '@domain';
 import type { ContextMenuTarget } from '../state/slices/uiSlice';
@@ -35,6 +39,8 @@ export interface GanttRowData {
   projectGroups: Map<string, string | null>;
   collapsedGroups: string[];
   toggleGroup: (groupId: string) => void;
+  moveMember: (memberName: string, direction: -1 | 1) => void;
+  reorderMember: (sourceMemberName: string, targetMemberName: string) => void;
   setSelectedTask: (task: NormalizedTask) => void;
   selectedTaskIds: string[];
   toggleTaskSelection: (task: NormalizedTask) => void;
@@ -364,6 +370,7 @@ const GanttRow = ({ index, style, data }: ListChildComponentProps<GanttRowData>)
     : [];
   const maxLoad = workloadSegments.reduce((max, segment) => Math.max(max, segment.count), 0);
   const showAggregateBars = isGroup && isCollapsed && workloadSegments.length > 0;
+  const canReorderMember = row.type === 'member';
 
   const handleRowContextMenu = (event: ReactMouseEvent<HTMLDivElement>) => {
     if (row.type !== 'project' || !row.projectId) {
@@ -383,12 +390,49 @@ const GanttRow = ({ index, style, data }: ListChildComponentProps<GanttRowData>)
     });
   };
 
+  const handleMemberDragStart = (event: ReactDragEvent<HTMLButtonElement>) => {
+    if (!canReorderMember) {
+      return;
+    }
+    event.stopPropagation();
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('application/x-rasuva-member', row.memberName);
+  };
+
+  const handleMemberDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
+    if (!canReorderMember) {
+      return;
+    }
+    const sourceMember = event.dataTransfer.types.includes('application/x-rasuva-member');
+    if (!sourceMember) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleMemberDrop = (event: ReactDragEvent<HTMLDivElement>) => {
+    if (!canReorderMember) {
+      return;
+    }
+    const sourceMember = event.dataTransfer.getData('application/x-rasuva-member');
+    if (!sourceMember || sourceMember === row.memberName) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    data.reorderMember(sourceMember, row.memberName);
+  };
+
   return (
     <div
       className={`gantt-row gantt-row--${row.type}`}
       style={rowStyle}
       onClick={() => row.task && data.setSelectedTask(row.task)}
       onContextMenu={handleRowContextMenu}
+      onDragOver={handleMemberDragOver}
+      onDrop={handleMemberDrop}
       data-row-type={dataRowType}
       data-row-id={dataRowId}
       data-member-name={row.memberName}
@@ -399,24 +443,65 @@ const GanttRow = ({ index, style, data }: ListChildComponentProps<GanttRowData>)
         style={{ width: data.labelWidth }}
       >
         {isGroup && groupId ? (
-          <button
-            type="button"
-            className="gantt-toggle"
-            title={row.label}
-            aria-expanded={!isCollapsed}
-            onClick={(event) => {
-              event.stopPropagation();
-              data.toggleGroup(groupId);
-            }}
-          >
-            <span className="gantt-toggle__icon">{isCollapsed ? '▸' : '▾'}</span>
-            <span className="gantt-toggle__text">{row.label}</span>
-            {maxLoad > 0 ? (
-              <span className={`gantt-load-badge gantt-load-badge--${getWorkloadLevel(maxLoad)}`}>
-                {maxLoad}
-              </span>
+          <div className="gantt-label-group">
+            {canReorderMember ? (
+              <button
+                type="button"
+                className="gantt-member-drag"
+                draggable
+                title="ドラッグして担当者を並び替え"
+                aria-label={`${row.label}をドラッグして並び替え`}
+                onClick={(event) => event.stopPropagation()}
+                onDragStart={handleMemberDragStart}
+              >
+                ↕
+              </button>
             ) : null}
-          </button>
+            <button
+              type="button"
+              className="gantt-toggle"
+              title={row.label}
+              aria-expanded={!isCollapsed}
+              onClick={(event) => {
+                event.stopPropagation();
+                data.toggleGroup(groupId);
+              }}
+            >
+              <span className="gantt-toggle__icon">{isCollapsed ? '▸' : '▾'}</span>
+              <span className="gantt-toggle__text">{row.label}</span>
+              {maxLoad > 0 ? (
+                <span className={`gantt-load-badge gantt-load-badge--${getWorkloadLevel(maxLoad)}`}>
+                  {maxLoad}
+                </span>
+              ) : null}
+            </button>
+            {canReorderMember ? (
+              <div className="gantt-member-order-actions" aria-label={`${row.label}の表示順`}>
+                <button
+                  type="button"
+                  title="上へ移動"
+                  aria-label={`${row.label}を上へ移動`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    data.moveMember(row.memberName, -1);
+                  }}
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  title="下へ移動"
+                  aria-label={`${row.label}を下へ移動`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    data.moveMember(row.memberName, 1);
+                  }}
+                >
+                  ↓
+                </button>
+              </div>
+            ) : null}
+          </div>
         ) : (
           <span className="gantt-label__text" title={row.label}>
             {row.label}

--- a/renderer/src/components/GanttView.tsx
+++ b/renderer/src/components/GanttView.tsx
@@ -184,7 +184,9 @@ const GanttView = ({ tasks, emptyLabel, getBarClassName }: GanttViewProps) => {
   const rangeStart = useAppStore((state) => state.rangeStart);
   const rangeEnd = useAppStore((state) => state.rangeEnd);
   const collapsedGroups = useAppStore((state) => state.collapsedGroups);
+  const memberOrder = useAppStore((state) => state.memberOrder);
   const setCollapsedGroups = useAppStore((state) => state.setCollapsedGroups);
+  const setMemberOrder = useAppStore((state) => state.setMemberOrder);
   const toggleGroup = useAppStore((state) => state.toggleGroup);
   const setFocusDate = useAppStore((state) => state.setFocusDate);
   const setSelectedTask = useAppStore((state) => state.setSelectedTask);
@@ -284,9 +286,15 @@ const GanttView = ({ tasks, emptyLabel, getBarClassName }: GanttViewProps) => {
     }
 
     const members = groupTasks(rangeFilteredTasks);
+    const orderedMemberNames = memberOrder.filter((memberName) => members.has(memberName));
+    const orderedMemberSet = new Set(orderedMemberNames);
+    const memberEntries = [
+      ...orderedMemberNames.map((memberName) => [memberName, members.get(memberName)!] as const),
+      ...Array.from(members.entries()).filter(([memberName]) => !orderedMemberSet.has(memberName))
+    ];
     const rows: GanttRowItem[] = [];
 
-    Array.from(members.entries()).forEach(([memberName, projects]) => {
+    memberEntries.forEach(([memberName, projects]) => {
       rows.push({
         id: `member:${memberName}`,
         type: 'member',
@@ -321,7 +329,53 @@ const GanttView = ({ tasks, emptyLabel, getBarClassName }: GanttViewProps) => {
     });
 
     return { rows, derivedRangeStart, derivedRangeEnd };
-  }, [rangeFilteredTasks]);
+  }, [rangeFilteredTasks, memberOrder]);
+
+  const displayedMemberNames = useMemo(() => {
+    const names: string[] = [];
+    rows.forEach((row) => {
+      if (row.type === 'member') {
+        names.push(row.memberName);
+      }
+    });
+    return names;
+  }, [rows]);
+
+  const moveMember = useCallback(
+    (memberName: string, direction: -1 | 1) => {
+      const currentIndex = displayedMemberNames.indexOf(memberName);
+      if (currentIndex < 0) {
+        return;
+      }
+      const nextIndex = currentIndex + direction;
+      if (nextIndex < 0 || nextIndex >= displayedMemberNames.length) {
+        return;
+      }
+      const nextOrder = [...displayedMemberNames];
+      const [moved] = nextOrder.splice(currentIndex, 1);
+      nextOrder.splice(nextIndex, 0, moved);
+      setMemberOrder(nextOrder);
+    },
+    [displayedMemberNames, setMemberOrder]
+  );
+
+  const reorderMember = useCallback(
+    (sourceMemberName: string, targetMemberName: string) => {
+      if (sourceMemberName === targetMemberName) {
+        return;
+      }
+      const sourceIndex = displayedMemberNames.indexOf(sourceMemberName);
+      const targetIndex = displayedMemberNames.indexOf(targetMemberName);
+      if (sourceIndex < 0 || targetIndex < 0) {
+        return;
+      }
+      const nextOrder = [...displayedMemberNames];
+      const [moved] = nextOrder.splice(sourceIndex, 1);
+      nextOrder.splice(targetIndex, 0, moved);
+      setMemberOrder(nextOrder);
+    },
+    [displayedMemberNames, setMemberOrder]
+  );
 
   const displayRangeStart = rangeStart ?? derivedRangeStart;
   const displayRangeEnd = rangeEnd ?? derivedRangeEnd;
@@ -628,6 +682,8 @@ const GanttView = ({ tasks, emptyLabel, getBarClassName }: GanttViewProps) => {
       projectGroups,
       collapsedGroups,
       toggleGroup,
+      moveMember,
+      reorderMember,
       setSelectedTask,
       selectedTaskIds,
       toggleTaskSelection,
@@ -663,6 +719,8 @@ const GanttView = ({ tasks, emptyLabel, getBarClassName }: GanttViewProps) => {
     projectGroups,
     collapsedGroups,
     toggleGroup,
+    moveMember,
+    reorderMember,
     setSelectedTask,
     selectedTaskIds,
     toggleTaskSelection,

--- a/renderer/src/pages/GanttPage.tsx
+++ b/renderer/src/pages/GanttPage.tsx
@@ -13,6 +13,8 @@ const GanttPage = () => {
   const setRange = useAppStore((state) => state.setRange);
   const collapsedGroups = useAppStore((state) => state.collapsedGroups);
   const setCollapsedGroups = useAppStore((state) => state.setCollapsedGroups);
+  const memberOrder = useAppStore((state) => state.memberOrder);
+  const setMemberOrder = useAppStore((state) => state.setMemberOrder);
   const collapseAll = useAppStore((state) => state.collapseAll);
   const expandAll = useAppStore((state) => state.expandAll);
   const isUnscheduledDrawerOpen = useAppStore((state) => state.isUnscheduledDrawerOpen);
@@ -68,30 +70,38 @@ const GanttPage = () => {
     }
     hasLoadedRef.current = false;
     let nextGroups: string[] | null = null;
+    let nextMemberOrder: string[] | null = null;
     try {
       const raw = localStorage.getItem(storageKey);
       if (raw) {
-        const parsed = JSON.parse(raw) as { collapsedGroups?: unknown };
+        const parsed = JSON.parse(raw) as { collapsedGroups?: unknown; memberOrder?: unknown };
         if (Array.isArray(parsed.collapsedGroups)) {
           nextGroups = parsed.collapsedGroups.filter(
+            (value): value is string => typeof value === 'string'
+          );
+        }
+        if (Array.isArray(parsed.memberOrder)) {
+          nextMemberOrder = parsed.memberOrder.filter(
             (value): value is string => typeof value === 'string'
           );
         }
       }
     } catch {
       nextGroups = null;
+      nextMemberOrder = null;
     }
     setCollapsedGroups(nextGroups ?? []);
+    setMemberOrder(nextMemberOrder ?? []);
     hasLoadedRef.current = true;
-  }, [storageKey, setCollapsedGroups]);
+  }, [storageKey, setCollapsedGroups, setMemberOrder]);
 
   useEffect(() => {
     if (!storageKey || !hasLoadedRef.current) {
       return;
     }
-    const payload = JSON.stringify({ collapsedGroups });
+    const payload = JSON.stringify({ collapsedGroups, memberOrder });
     localStorage.setItem(storageKey, payload);
-  }, [storageKey, collapsedGroups]);
+  }, [storageKey, collapsedGroups, memberOrder]);
 
   useEffect(() => {
     const isTypingElement = (target: EventTarget | null) => {

--- a/renderer/src/pages/ViewsPage.tsx
+++ b/renderer/src/pages/ViewsPage.tsx
@@ -21,6 +21,7 @@ const ViewsPage = () => {
   const rangeStart = useAppStore((state) => state.rangeStart);
   const rangeEnd = useAppStore((state) => state.rangeEnd);
   const collapsedGroups = useAppStore((state) => state.collapsedGroups);
+  const memberOrder = useAppStore((state) => state.memberOrder);
 
   useEffect(() => {
     loadViews();
@@ -35,7 +36,8 @@ const ViewsPage = () => {
       zoom,
       rangeStart,
       rangeEnd,
-      collapsedGroups
+      collapsedGroups,
+      memberOrder
     };
     await saveView(name.trim(), state);
     setName('');
@@ -78,6 +80,7 @@ const ViewsPage = () => {
                     : '指定なし'}
                 </span>
                 <span>折りたたみ {(view.state.collapsedGroups ?? []).length} 件</span>
+                <span>担当者順 {(view.state.memberOrder ?? []).length} 件</span>
               </div>
               <div className="list-actions">
                 <button

--- a/renderer/src/state/slices/viewSlice.ts
+++ b/renderer/src/state/slices/viewSlice.ts
@@ -5,11 +5,13 @@ import type { AppState } from '../store';
 export interface ViewSlice {
   views: SavedViewItem[];
   collapsedGroups: string[];
+  memberOrder: string[];
   rangeStart: string | null;
   rangeEnd: string | null;
   loadViews: () => Promise<void>;
   saveView: (name: string, state: SavedViewState) => Promise<void>;
   setCollapsedGroups: (groups: string[]) => void;
+  setMemberOrder: (members: string[]) => void;
   toggleGroup: (groupId: string) => void;
   collapseAll: (groupIds: string[]) => void;
   expandAll: () => void;
@@ -17,12 +19,12 @@ export interface ViewSlice {
   applyViewState: (state: SavedViewState) => void;
 }
 
-const API_MISSING_MESSAGE =
-  'Preload API が利用できません。preload の読み込みを確認してください。';
+const API_MISSING_MESSAGE = 'Preload API が利用できません。preload の読み込みを確認してください。';
 
 export const createViewSlice: StateCreator<AppState, [], [], ViewSlice> = (set, get) => ({
   views: [],
   collapsedGroups: [],
+  memberOrder: [],
   rangeStart: null,
   rangeEnd: null,
   loadViews: async () => {
@@ -62,6 +64,7 @@ export const createViewSlice: StateCreator<AppState, [], [], ViewSlice> = (set, 
     }
   },
   setCollapsedGroups: (groups) => set({ collapsedGroups: groups }),
+  setMemberOrder: (members) => set({ memberOrder: Array.from(new Set(members)) }),
   toggleGroup: (groupId) => {
     set((state) => {
       const exists = state.collapsedGroups.includes(groupId);
@@ -86,6 +89,7 @@ export const createViewSlice: StateCreator<AppState, [], [], ViewSlice> = (set, 
   applyViewState: (state) => {
     set({
       collapsedGroups: state.collapsedGroups ?? [],
+      memberOrder: state.memberOrder ?? [],
       rangeStart: state.rangeStart ?? null,
       rangeEnd: state.rangeEnd ?? null
     });

--- a/renderer/src/styles/app.css
+++ b/renderer/src/styles/app.css
@@ -1211,6 +1211,50 @@ body {
   min-width: 0;
 }
 
+.gantt-label-group {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+}
+
+.gantt-member-drag,
+.gantt-member-order-actions button {
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: #fffaf2;
+  color: var(--text-muted);
+  display: inline-grid;
+  place-items: center;
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.gantt-member-drag {
+  cursor: grab;
+}
+
+.gantt-member-drag:active {
+  cursor: grabbing;
+}
+
+.gantt-member-order-actions {
+  display: flex;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+
+.gantt-member-drag:hover,
+.gantt-member-order-actions button:hover {
+  border-color: rgba(173, 126, 54, 0.75);
+  color: var(--text);
+}
+
 .gantt-toggle__icon {
   font-size: 12px;
   color: var(--text-muted);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Ganttビューでのメンバー順序の並び替え機能を追加しました。メンバー行は上下ボタンまたはドラッグ&ドロップで移動可能になり、設定はビュー保存時に永続化されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orenodinner/rasuva/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->